### PR TITLE
Additional support of Wire1 to Wire5 interface

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2013-2020 Rob Tillaart
+Copyright (c) 2013-2021 Rob Tillaart
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/PCF8574.cpp
+++ b/PCF8574.cpp
@@ -44,27 +44,112 @@
 #include "PCF8574.h"
 
 
-PCF8574::PCF8574(const uint8_t deviceAddress)
+PCF8574::PCF8574(uint8_t interfaceIndex,const uint8_t deviceAddress)
 {
+  _interfaceIndex = interfaceIndex;
   _address = deviceAddress;
   _dataIn = 0;
   _dataOut = 0xFF;
   _buttonMask = 0xFF;
-  _error = PCF8574_OK;
+  
+  if(_interfaceIndex >= PCF8574_INTERFACE_NO_OF_INTERFACES){
+    _error = PCF8574_INTERFACE_NOT_AVAILABLE;
+  }
+  else{
+    _error = PCF8574_OK;
+  }
 }
 
 #if defined (ESP8266) || defined(ESP32)
 void PCF8574::begin(uint8_t sda, uint8_t scl, uint8_t val)
 {
-  Wire.begin(sda, scl);
-  PCF8574::write8(val);
+  if(_interfaceIndex < PCF8574_INTERFACE_NO_OF_INTERFACES){
+
+    switch(_interfaceIndex){
+//always available since "every" Arduino has at least one I2C interface
+      case PCF8574_INTERFACE_WIRE:
+        Wire.begin(sda, scl);
+        break;
+#ifdef WIRE_IMPLEMENT_WIRE1
+      case PCF8574_INTERFACE_WIRE1:
+        Wire1.begin(sda, scl);
+        break;
+#endif
+#ifdef WIRE_IMPLEMENT_WIRE2
+      case PCF8574_INTERFACE_WIRE2:
+        Wire2.begin(sda, scl);
+        break;
+#endif
+#ifdef WIRE_IMPLEMENT_WIRE3
+      case PCF8574_INTERFACE_WIRE3:
+        Wire3.begin(sda, scl);
+        break;
+#endif
+#ifdef WIRE_IMPLEMENT_WIRE4
+      case PCF8574_INTERFACE_WIRE4:
+        Wire4.begin(sda, scl);
+        break;
+#endif
+#ifdef WIRE_IMPLEMENT_WIRE5
+      case PCF8574_INTERFACE_WIRE5:
+        Wire5.begin(sda, scl);
+        break;
+#endif
+      default:
+        break;
+    }
+  
+    PCF8574::write8(val);
+  }
+  else{
+    _error = PCF8574_INTERFACE_NOT_AVAILABLE;
+  }
 }
 #endif
 
 void PCF8574::begin(uint8_t val)
 {
-  Wire.begin();
-  PCF8574::write8(val);
+  if(_interfaceIndex < PCF8574_INTERFACE_NO_OF_INTERFACES){
+	  
+    switch(_interfaceIndex){
+//always available since "every" Arduino has at least one I2C interface
+      case PCF8574_INTERFACE_WIRE:
+        Wire.begin();
+        break;
+#ifdef WIRE_IMPLEMENT_WIRE1
+      case PCF8574_INTERFACE_WIRE1:
+        Wire1.begin();
+        break;
+#endif
+#ifdef WIRE_IMPLEMENT_WIRE2
+      case PCF8574_INTERFACE_WIRE2:
+        Wire2.begin();
+        break;
+#endif
+#ifdef WIRE_IMPLEMENT_WIRE3
+      case PCF8574_INTERFACE_WIRE3:
+        Wire3.begin();
+        break;
+#endif
+#ifdef WIRE_IMPLEMENT_WIRE4
+      case PCF8574_INTERFACE_WIRE4:
+        Wire4.begin();
+        break;
+#endif
+#ifdef WIRE_IMPLEMENT_WIRE5
+      case PCF8574_INTERFACE_WIRE5:
+        Wire5.begin();
+        break;
+#endif
+      default:
+        break;
+    }
+    
+    PCF8574::write8(val);
+  }
+  else{
+    _error = PCF8574_INTERFACE_NOT_AVAILABLE;
+  }
 }
 
 // removed Wire.beginTransmission(addr);
@@ -74,21 +159,148 @@ void PCF8574::begin(uint8_t val)
 // TODO @800KHz -> ??
 uint8_t PCF8574::read8()
 {
-  if (Wire.requestFrom(_address, (uint8_t)1) != 1)
-  {
+  if(_interfaceIndex < PCF8574_INTERFACE_NO_OF_INTERFACES){
+    
+    uint8_t requestForm_response = 0;
+    
+    switch(_interfaceIndex){
+//always available since "every" Arduino has at least one I2C interface
+      case PCF8574_INTERFACE_WIRE:
+        requestForm_response = Wire.requestFrom(_address, (uint8_t)1);
+        break;
+#ifdef WIRE_IMPLEMENT_WIRE1
+      case PCF8574_INTERFACE_WIRE1:
+        requestForm_response = Wire1.requestFrom(_address, (uint8_t)1);
+        break;
+#endif
+#ifdef WIRE_IMPLEMENT_WIRE2
+      case PCF8574_INTERFACE_WIRE2:
+        requestForm_response = Wire2.requestFrom(_address, (uint8_t)1);
+        break;
+#endif
+#ifdef WIRE_IMPLEMENT_WIRE3
+      case PCF8574_INTERFACE_WIRE3:
+        requestForm_response = Wire3.requestFrom(_address, (uint8_t)1);
+        break;
+#endif
+#ifdef WIRE_IMPLEMENT_WIRE4
+      case PCF8574_INTERFACE_WIRE4:
+        requestForm_response = Wire4.requestFrom(_address, (uint8_t)1);
+        break;
+#endif
+#ifdef WIRE_IMPLEMENT_WIRE5
+      case PCF8574_INTERFACE_WIRE5:
+        requestForm_response = Wire5.requestFrom(_address, (uint8_t)1);
+        break;
+#endif
+      default:
+        break;
+    }
+    
+    if (requestForm_response != 1)
+    {
+      _error = PCF8574_I2C_ERROR;
+      return _dataIn; // last value
+    }
+    
+    switch(_interfaceIndex){
+//always available since "every" Arduino has at least one I2C interface
+      case PCF8574_INTERFACE_WIRE:
+        _dataIn = Wire.read();
+        break;
+#ifdef WIRE_IMPLEMENT_WIRE1
+      case PCF8574_INTERFACE_WIRE1:
+        _dataIn = Wire1.read();
+        break;
+#endif
+#ifdef WIRE_IMPLEMENT_WIRE2
+      case PCF8574_INTERFACE_WIRE2:
+        _dataIn = Wire2.read();
+        break;
+#endif
+#ifdef WIRE_IMPLEMENT_WIRE3
+      case PCF8574_INTERFACE_WIRE3:
+        _dataIn = Wire3.read();
+        break;
+#endif
+#ifdef WIRE_IMPLEMENT_WIRE4
+      case PCF8574_INTERFACE_WIRE4:
+        _dataIn = Wire4.read();
+        break;
+#endif
+#ifdef WIRE_IMPLEMENT_WIRE5
+      case PCF8574_INTERFACE_WIRE5:
+        _dataIn = Wire5.read();
+        break;
+#endif
+      default:
+        break;
+    }
+    
+    return _dataIn;
+  }
+  else{
     _error = PCF8574_I2C_ERROR;
     return _dataIn; // last value
   }
-  _dataIn = Wire.read();
-  return _dataIn;
 }
 
 void PCF8574::write8(const uint8_t value)
 {
-  _dataOut = value;
-  Wire.beginTransmission(_address);
-  Wire.write(_dataOut);
-  _error = Wire.endTransmission();
+  if(_interfaceIndex < PCF8574_INTERFACE_NO_OF_INTERFACES){
+	  
+    _dataOut = value;
+    
+    switch(_interfaceIndex){
+//always available since "every" Arduino has at least one I2C interface
+      case PCF8574_INTERFACE_WIRE:
+	      Wire.beginTransmission(_address);
+        Wire.write(_dataOut);
+        _error = Wire.endTransmission();
+        break;
+#ifdef WIRE_IMPLEMENT_WIRE1
+      case PCF8574_INTERFACE_WIRE1:
+	      Wire1.beginTransmission(_address);
+        Wire1.write(_dataOut);
+        _error = Wire1.endTransmission();
+        break;
+#endif
+#ifdef WIRE_IMPLEMENT_WIRE2
+      case PCF8574_INTERFACE_WIRE2:
+	      Wire2.beginTransmission(_address);
+        Wire2.write(_dataOut);
+        _error = Wire2.endTransmission();
+        break;
+#endif
+#ifdef WIRE_IMPLEMENT_WIRE3
+      case PCF8574_INTERFACE_WIRE3:
+	      Wire3.beginTransmission(_address);
+        Wire3.write(_dataOut);
+        _error = Wire3.endTransmission();
+        break;
+#endif
+#ifdef WIRE_IMPLEMENT_WIRE4
+      case PCF8574_INTERFACE_WIRE4:
+	      Wire4.beginTransmission(_address);
+        Wire4.write(_dataOut);
+        _error = Wire4.endTransmission();
+        break;
+#endif
+#ifdef WIRE_IMPLEMENT_WIRE5
+      case PCF8574_INTERFACE_WIRE5:
+	      Wire5.beginTransmission(_address);
+        Wire5.write(_dataOut);
+        _error = Wire5.endTransmission();
+        break;
+#endif
+      default:
+        break;
+    }
+    
+  }
+  else{
+    _error = PCF8574_INTERFACE_NOT_AVAILABLE;
+  }
 }
 
 uint8_t PCF8574::read(const uint8_t pin)

--- a/PCF8574.cpp
+++ b/PCF8574.cpp
@@ -2,12 +2,13 @@
 //    FILE: PCF8574.cpp
 //  AUTHOR: Rob Tillaart
 //    DATE: 02-febr-2013
-// VERSION: 0.2.4
+// VERSION: 0.2.5
 // PURPOSE: Arduino library for PCF8574 - I2C IO expander
 //     URL: https://github.com/RobTillaart/PCF8574
 //          http://forum.arduino.cc/index.php?topic=184800
 //
 // HISTORY:
+// 0.2.5  2020-01-03  Added support of Wire1, Wire2, Wire3, Wire4 and Wire5 interfaces
 // 0.2.4  2020-12-17  fix #6 tag problem 0.2.3
 // 0.2.3  2020-12-14  fix #6 readButton8 ambiguity
 // 0.2.2  2020-12-07  add Arduino-ci + start unit test + Wire.h in PCF8574.h

--- a/PCF8574.h
+++ b/PCF8574.h
@@ -17,15 +17,38 @@
 
 #define PCF8574_LIB_VERSION "0.2.4"
 
-#define PCF8574_OK          0x00
-#define PCF8574_PIN_ERROR   0x81
-#define PCF8574_I2C_ERROR   0x82
+#define PCF8574_OK          			      0x00
+#define PCF8574_INTERFACE_NOT_AVAILABLE 0x80
+#define PCF8574_PIN_ERROR   			      0x81
+#define PCF8574_I2C_ERROR   			      0x82
 
+
+enum{
+	PCF8574_INTERFACE_WIRE  = (uint8_t)0,
+#ifdef WIRE_IMPLEMENT_WIRE1
+	PCF8574_INTERFACE_WIRE1 = (uint8_t)1,
+#endif
+#ifdef WIRE_IMPLEMENT_WIRE2
+	PCF8574_INTERFACE_WIRE2 = (uint8_t)2,
+#endif
+#ifdef WIRE_IMPLEMENT_WIRE3
+	PCF8574_INTERFACE_WIRE3 = (uint8_t)3,
+#endif
+#ifdef WIRE_IMPLEMENT_WIRE4
+	PCF8574_INTERFACE_WIRE4 = (uint8_t)4,
+#endif
+#ifdef WIRE_IMPLEMENT_WIRE5
+	PCF8574_INTERFACE_WIRE5 = (uint8_t)5,
+#endif
+	
+	/* ============================ */
+	PCF8574_INTERFACE_NO_OF_INTERFACES,
+};
 
 class PCF8574
 {
 public:
-  explicit PCF8574(const uint8_t deviceAddress);
+  explicit PCF8574(uint8_t interfaceIndex, const uint8_t deviceAddress);
 
 #if defined (ESP8266) || defined(ESP32)
   void   begin(uint8_t sda, uint8_t scl, uint8_t val = 0xFF);
@@ -58,6 +81,7 @@ public:
   int lastError();
 
 private:
+  uint8_t _interfaceIndex;
   uint8_t _address;
   uint8_t _dataIn;
   uint8_t _dataOut;

--- a/PCF8574.h
+++ b/PCF8574.h
@@ -3,7 +3,7 @@
 //    FILE: PCF8574.H
 //  AUTHOR: Rob Tillaart
 //    DATE: 02-febr-2013
-// VERSION: 0.2.4
+// VERSION: 0.2.5
 // PURPOSE: Arduino library for PCF8574 - I2C IO expander
 //     URL: https://github.com/RobTillaart/PCF8574
 //          http://forum.arduino.cc/index.php?topic=184800
@@ -15,12 +15,12 @@
 #include "Arduino.h"
 #include "Wire.h"
 
-#define PCF8574_LIB_VERSION "0.2.4"
+#define PCF8574_LIB_VERSION "0.2.5"
 
-#define PCF8574_OK          			      0x00
+#define PCF8574_OK          		0x00
 #define PCF8574_INTERFACE_NOT_AVAILABLE 0x80
-#define PCF8574_PIN_ERROR   			      0x81
-#define PCF8574_I2C_ERROR   			      0x82
+#define PCF8574_PIN_ERROR   		0x81
+#define PCF8574_I2C_ERROR   		0x82
 
 
 enum{

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ playfull but still are useful.
 
 ## Interface
 
-- **PCF8574(deviceAddress)** Constructor with device address as parameter.
+- **PCF8574(interfaceAddress, deviceAddress)** Constructor with interface address and device address as parameter.
 - **begin(val = 0xFF)** set the initial value for the pins and masks.
 - **begin(sda, scl, val = 0xFF)** idem, for the ESP32 where one can choose the I2C pins
 What needs to be added in the future is a parameter to choose another Wire interface

--- a/examples/buttonRead/buttonRead.ino
+++ b/examples/buttonRead/buttonRead.ino
@@ -27,7 +27,7 @@
 #include <PCF8574.h>
 #include <Wire.h>
 
-PCF8574 pcf20(0x20);
+PCF8574 pcf20(PCF8574_INTERFACE_WIRE, 0x20);
 
 const byte onboardLed = 13;
 const byte PcfButtonLedPin = 0;

--- a/examples/buttonRead8/buttonRead8.ino
+++ b/examples/buttonRead8/buttonRead8.ino
@@ -27,7 +27,7 @@
 #include <PCF8574.h>
 #include <Wire.h>
 
-PCF8574 pcf20(0x20);
+PCF8574 pcf20(PCF8574_INTERFACE_WIRE, 0x20);
 
 const byte onboardLed = 13;
 const byte PcfButtonLedPin = 0;

--- a/library.json
+++ b/library.json
@@ -1,7 +1,7 @@
 {
   "name": "PCF8574",
   "keywords": "I2C, PCF8574, PCF8574A, IO, I/O, shift, rotate",
-  "description": "Arduino library for PCF8574 - I2C IO expander, implements shift rotate.",
+  "description": "Arduino library for PCF8574 - I2C IO expander, implements shift rotate, supporting Wire, Wire1, Wire2, Wire3, Wire4 and Wire5 interface",
   "authors":
   [
     {
@@ -15,7 +15,7 @@
     "type": "git",
     "url": "https://github.com/RobTillaart/PCF8574.git"
   },
-  "version":"0.2.4",
+  "version":"0.2.5",
   "frameworks": "arduino",
   "platforms": "*"
 }

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=PCF8574
-version=0.2.4
+version=0.2.5
 author=Rob Tillaart <rob.tillaart@gmail.com>
 maintainer=Rob Tillaart <rob.tillaart@gmail.com>
 sentence=Arduino library for PCF8574 - I2C IO expander


### PR DESCRIPTION
Hi Rob,

is talked in the issue i have made some modifications on your code to support Wire1, Wire2, Wire3, Wire4 and Wire5 interface.
I have running the code on an Teensy 4.1 using Wire2 interface.
Unfortunatelly i do not have another board to test the complete code.

To choose the interface i have modified the constructor to await the index of the wanted interface. In case there is no interface with the given index i have added an error: `#define PCF8574_INTERFACE_NOT_AVAILABLE 0x80`
Maybe you want to change the value of the error.

The available interfaces are given in the header file.
In the methods where the interface is used i have entered switch/case to choose the wanted interface. To avoid issues if there is no interface with the given index i have added a check before the switch/case.

Feel free to contact me in case of questions!
Best regards 
mattbue