### PR TITLE
Master mode issue

### DIFF
--- a/PCF8574.cpp
+++ b/PCF8574.cpp
@@ -61,7 +61,7 @@ PCF8574::PCF8574(const uint8_t deviceAddress, TwoWire *wire)
 
 
 #if defined (ESP8266) || defined(ESP32)
-bool PCF8574::begin(uint8_t dataPin, uint8_t clockPin, uint8_t value)
+bool PCF8574::begin(int dataPin, int clockPin, uint8_t value)
 {
   _wire      = &Wire;
   if ((dataPin < 255) && (clockPin < 255))

--- a/PCF8574.h
+++ b/PCF8574.h
@@ -34,7 +34,7 @@ public:
   explicit PCF8574(const uint8_t deviceAddress = 0x20, TwoWire *wire = &Wire);
 
 #if defined (ESP8266) || defined(ESP32)
-  bool    begin(uint8_t sda, uint8_t scl, uint8_t value = PCF8574_INITIAL_VALUE);
+  bool    begin(int sda, int scl, uint8_t value = PCF8574_INITIAL_VALUE);
 #endif
   bool    begin(uint8_t value = PCF8574_INITIAL_VALUE);
   bool    isConnected();


### PR DESCRIPTION
Wire.cpp has two functions:

bool TwoWire::begin(int sdaPin, int sclPin, uint32_t frequency)
bool TwoWire::begin(uint8_t addr, int sdaPin, int sclPin, uint32_t frequency)

dataPin clockPin from
bool PCF8574::begin(uint8_t dataPin, uint8_t clockPin, uint8_t value)
should be of type int to use the correct function.
